### PR TITLE
Ignore  mod and sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 */.DS_Store
 sputnik
+go.mod
+go.sum


### PR DESCRIPTION
_vgo_ creates 2 files when getting dependencies, `go.mod` and `go.sum`. Since they're always created and modified I am ignoring them. 